### PR TITLE
Basic init.sql for testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./postgres/data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
   adminer:
     container_name: adminer

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS users (
+    user_name text primary key,
+    name text,
+    password text,
+    wallet integer
+);
+
+CREATE TABLE IF NOT EXISTS stocks (
+    stock_id serial unique primary key,
+    stock_name text,
+    current_price integer
+);


### PR DESCRIPTION
Added basic init script for postgres. Removed postgres volume folder as it was interfering with initialization. You need to remove your postgres containers and rebuild them for the init to work.