### PR TITLE
Add go.work files containing our go modules

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,8 @@
+go 1.21.6
+
+use (
+ ./authentication
+ ./engine
+ ./setup
+ ./transaction
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,6 @@
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=


### PR DESCRIPTION
Had to add a go.work file that outlines the go modules being used in our project. This is due to the go-pls language server not being able to find the go modules in our project.
