### PR TITLE
Small string fixes

### DIFF
--- a/engine/main.go
+++ b/engine/main.go
@@ -358,7 +358,7 @@ func postprocessingRemoveBuyOrder(order Order) {
 			fmt.Println("Error deleting stock transaction: ", err)
 		}
 	} else {
-		fmt.Println("Remove PARTIALLY_FULFILLED buy order")
+		fmt.Println("Remove PARTIAL_FULFILLED buy order")
 		if err := updateMoneyWallet(order.UserName, order, order.Price, order.Quantity, true); err != nil {
 			fmt.Println("Error updating wallet: ", err)
 		}
@@ -384,7 +384,7 @@ func postprocessingRemoveSellOrder(order Order) {
 			fmt.Println("Error deleting stock transaction: ", err)
 		}
 	} else {
-		fmt.Println("Remove PARTIALLY_FULFILLED sell order")
+		fmt.Println("Remove PARTIAL_FULFILLED sell order")
 		if err := updateStockPortfolio(order.UserName, order, order.Quantity, true); err != nil {
 			fmt.Println("Error updating stock portfolio: ", err)
 		}
@@ -642,7 +642,7 @@ func partialFulfillSellOrder(book *OrderBook, order *Order, tradeQuantity int) {
 		fmt.Println("Error updating wallet: ", err)
 	}
 
-	if err := setStatus(order, "PARTIALLY_FULFILLED", false); err != nil {
+	if err := setStatus(order, "PARTIAL_FULFILLED", false); err != nil {
 		fmt.Println("Error setting status: ", err)
 	}
 
@@ -678,7 +678,7 @@ func partialFulfillBuyOrder(book *OrderBook, order *Order, tradeQuantity int) {
 		fmt.Println("Error updating stock portfolio: ", err)
 	}
 
-	if err := setStatus(order, "PARTIALLY_FULFILLED", false); err != nil {
+	if err := setStatus(order, "PARTIAL_FULFILLED", false); err != nil {
 		fmt.Println("Error setting status: ", err)
 	}
 
@@ -955,7 +955,7 @@ func setStatus(order *Order, status string, isUpdateWalletTxId bool) error {
 	}
 	defer db.Close()
 
-	if status == "PARTIALLY_FULFILLED" {
+	if status == "PARTIAL_FULFILLED" {
 		order.Status = status
 	}
 

--- a/tests/Seng468_Report1.jmx
+++ b/tests/Seng468_Report1.jmx
@@ -71,7 +71,7 @@
           </elementProp>
         </collectionProp>
       </elementProp>
-    </TestPlan>
+          </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="User 1 Thread">
         <intProp name="ThreadGroup.num_threads">1</intProp>
@@ -1653,7 +1653,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -1671,7 +1671,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_type JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_type</stringProp>
-            <stringProp name="EXPECTED_VALUE">MARKET</stringProp>
+            <stringProp name="EXPECTED_VALUE">LIMIT</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -3358,7 +3358,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -3421,7 +3421,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[3].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[3].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4165,7 +4165,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[1].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[1].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4228,7 +4228,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4687,7 +4687,7 @@
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -4761,11 +4761,11 @@
         <stringProp name="filename"></stringProp>
       </ResultCollector>
       <hashTree/>
-      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
         <collectionProp name="HeaderManager.headers"/>
       </HeaderManager>
       <hashTree/>
-      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults">
+      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
           <collectionProp name="Arguments.arguments"/>
         </elementProp>

--- a/tests/Seng468_Report1_No_Delay.jmx
+++ b/tests/Seng468_Report1_No_Delay.jmx
@@ -71,7 +71,7 @@
           </elementProp>
         </collectionProp>
       </elementProp>
-    </TestPlan>
+          </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="User 1 Thread">
         <intProp name="ThreadGroup.num_threads">1</intProp>
@@ -1653,7 +1653,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -1671,7 +1671,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_type JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_type</stringProp>
-            <stringProp name="EXPECTED_VALUE">MARKET</stringProp>
+            <stringProp name="EXPECTED_VALUE">LIMIT</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -3358,7 +3358,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -3421,7 +3421,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[3].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[3].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4161,7 +4161,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[1].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[1].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4224,7 +4224,7 @@
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="data[2].order_status JSON Assertion" enabled="true">
             <stringProp name="JSON_PATH">$.data[2].order_status</stringProp>
-            <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
+            <stringProp name="EXPECTED_VALUE">COMPLETED</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
@@ -4720,7 +4720,7 @@
         </ResultCollector>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>


### PR DESCRIPTION
- `PARTIALLY_FULFILLED` -> `PARTIAL_FULFILLED`
- Jmeter test plan `COMPLETE` -> `COMPLETED`
- Test case 24 MARKET order should be a LIMIT order